### PR TITLE
Low: findif.sh: Log addition at the time of the error

### DIFF
--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -91,26 +91,26 @@ findif()
     ipcheck_ipv6 $match
     if [ $? = 1 ] ; then
       ocf_log err "IP address [$match] not valid."
-      return 6
+      return $OCF_ERR_CONFIGURED
     fi
     if [ -n "$NIC" ] ; then
       ifcheck_ipv6 $NIC
       if [ $? = 1 ] ; then
         ocf_log err "Unknown interface [$NIC] No such device."
-        return 6
+        return $OCF_ERR_CONFIGURED
       fi
     else
       echo $match | grep -qis '^fe80::'
       if [ $? = 0 ] ; then
         ocf_log err "IP address (Link Local Address) [$match] not available."
-        return 1
+        return $OCF_ERR_CONFIGURED
       fi
     fi
     if [ -n "$NETMASK" ] ; then
       prefixcheck $NETMASK 128
       if [ $? = 1 ] ; then
         ocf_log err "Invalid netmask specification [$NETMASK]."
-        return 6
+        return $OCF_ERR_CONFIGURED
       fi
       match=$match/$NETMASK
     fi
@@ -119,20 +119,20 @@ findif()
     ipcheck_ipv4 $match
     if [ $? = 1 ] ; then
       ocf_log err "IP address [$match] not valid."
-      return 6
+      return $OCF_ERR_CONFIGURED
     fi
     if [ -n "$NIC" ] ; then
       ifcheck_ipv4 $NIC
       if [ $? = 1 ] ; then
         ocf_log err "Unknown interface [$NIC] No such device."
-        return 6
+        return $OCF_ERR_CONFIGURED
       fi
     fi
     if [ -n "$NETMASK" ] ; then
       prefixcheck $NETMASK 32
       if [ $? = 1 ] ; then
         ocf_log err "Invalid netmask specification [$NETMASK]."
-        return 6
+        return $OCF_ERR_CONFIGURED
       fi
       match=$match/$NETMASK
     fi
@@ -140,7 +140,7 @@ findif()
       ipcheck_ipv4 $BRDCAST
       if [ $? = 1 ] ; then
         ocf_log err "Invalid broadcast address [$BRDCAST]."
-        return 6
+        return $OCF_ERR_CONFIGURED
       fi
     fi
     scope="scope link"
@@ -161,13 +161,13 @@ findif()
   if [ -z "$NIC" -o -z "$NETMASK" ] ; then
     if [ $# = 0 ] ; then
       ocf_log err "Unable to find nic or netmask."
-      return 1
+      return $OCF_ERR_GENERIC
     fi
     case $1 in
     */*) : OK ;;
     *)
       ocf_log err "Unable to find cidr_netmask."
-      return 1 ;;
+      return $OCF_ERR_GENERIC ;;
     esac
   fi
   [ -z "$NIC" ] && NIC=$3
@@ -182,9 +182,9 @@ findif()
   else
     if [ -z "$OCF_RESKEY_nic" -a "$NETMASK" != "${1#*/}" ] ; then
       ocf_log err "Unable to find nic, or netmask mismatch."
-      return 1
+      return $OCF_ERR_GENERIC
     fi
   fi
   echo "$NIC netmask $NETMASK broadcast $BRDCAST"
-  return 0
+  return $OCF_SUCCESS
 }


### PR DESCRIPTION
I added the log at the time of the error for findif.sh.

The test results are as follows.
The line of the asterisk outputs it with a test cord.

---

 **\* Test 1-01:IPv4:IP check
 **\* IP:[192.168.a.1]
 **\* Test Run findif
ERROR: IP address [192.168.a.1] not valid.
 **\* result code:[6]

 **\* Test 1-02:IPv4:NIC check
 **\* IP:[192.168.1.1]
 **\* NIC:[a]
 **\* Test Run findif
ERROR: Unknown interface [a] No such device.
 **\* result code:[6]

 **\* Test 1-03:IPv4:NETMASK check
 **\* IP:[192.168.1.1]
 **\* NIC:[eth0]
 **\* NETMASK:[a]
 **\* Test Run findif
ERROR: Invalid netmask specification [a].
 **\* result code:[6]

 **\* Test 1-04:IPv4:broadcast check
 **\* IP:[192.168.1.1]
 **\* NIC:[eth0]
 **\* NETMASK:[24]
 **\* BRDCAST:[192.168.1.a]
 **\* Test Run findif
ERROR: Invalid broadcast address [192.168.1.a].
 **\* result code:[6]

 **\* Test 1-05:IPv4:success
 **\* IP:[192.168.1.1]
 **\* NIC:[eth0]
 **\* NETMASK:[16]
 **\* Test Run findif
eth0 netmask 16 broadcast
 **\* result code:[0]

---

 **\* Test 2-01:IPv6:IP check
 **\* IP:[fd00:172:20:25::100.]
 **\* Test Run findif
ERROR: IP address [fd00:172:20:25::100.] not valid.
 **\* result code:[6]

 **\* Test 2-02:IPv6:NIC check
 **\* IP:[fd00:172:20:25::100]
 **\* NIC:[a]
 **\* Test Run findif
ERROR: Unknown interface [a] No such device.
 **\* result code:[6]

 **\* Test 2-03:IPv6:NETMASK check
 **\* IP:[fd00:172:20:25::100]
 **\* NIC:[eth0]
 **\* NETMASK:[a]
 **\* Test Run findif
ERROR: Invalid netmask specification [a].
 **\* result code:[6]

 **\* Test 2-04:IPv6:IP check(Link Local address)
 **\* IP:[fe80::172:20:25:100]
 **\* Test Run findif
ERROR: IP address (Link Local Address) [fe80::172:20:25:100] not available.
 **\* result code:[1]

 **\* Test 2-05:IPv6:NIC,NETMASK check
 **\* IP:[fe80:172:20:25::100]
 **\* Test Run findif
ERROR: Unable to find nic or netmask.
 **\* result code:[1]

 **\* Test 2-06:IPv6:NIC,NETMASK check
 **\* IP:[fd00:172:20:25::100]
 **\* NETMASK:[80]
 **\* Test Run findif
ERROR: Unable to find nic, or netmask mismatch.
 **\* result code:[1]

 **\* Test 2-07:IPv6:success
 **\* IP:[fd00:172:20:25::100]
 **\* NIC:[eth0]
 **\* Test Run findif
eth0 netmask 64 broadcast
 **\* result code:[0]
